### PR TITLE
added tooltip to bridge markers to display bridge site name and implemented smooth zoom in

### DIFF
--- a/src/components/pages/Home/Mapbox.js
+++ b/src/components/pages/Home/Mapbox.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
-import ReactMapGl, { Marker } from 'react-map-gl';
+import ReactMapGl, { Marker, FlyToInterpolator } from 'react-map-gl';
 import { UpCircleFilled } from '@ant-design/icons';
+import { Tooltip } from 'antd';
 
 //DUMMY DATA TO BE DELETED:
 let mapData = [
@@ -37,6 +38,19 @@ function Mapbox() {
     height: '100vh',
     zoom: 10,
   });
+
+  const ZoomIn = bridge => {
+    setViewport({
+      latitude: bridge.latitude,
+      longitude: bridge.longitude,
+      width: '100vw',
+      height: '100vh',
+      zoom: 15,
+      transitionInterpolator: new FlyToInterpolator({ speed: 3 }),
+      transitionDuration: 'auto',
+    });
+  };
+
   return (
     <div>
       {/* render map */}
@@ -55,16 +69,18 @@ function Mapbox() {
         {/* currently just showing bridge lats/longs */}
         {mapData.map(bridge => {
           return (
-            <Marker
-              key={bridge.id}
-              latitude={bridge.latitude}
-              longitude={bridge.longitude}
-            >
-              {/* bridge marker placeholder for now, but I like it. */}
-              <UpCircleFilled style={{ fontSize: '20px', color: 'green' }} />
+            <div key={bridge.id} onClick={() => ZoomIn(bridge)}>
+              <Marker latitude={bridge.latitude} longitude={bridge.longitude}>
+                <Tooltip title={bridge.site_name}>
+                  {/* bridge marker placeholder for now, but I like it. */}
+                  <UpCircleFilled
+                    style={{ fontSize: '20px', color: 'green' }}
+                  />
+                </Tooltip>
 
-              {/* this will be the bridge marker, need to upload svg for bridge icon to stylemaker on mapbox./or do it locally here */}
-            </Marker>
+                {/* this will be the bridge marker, need to upload svg for bridge icon to stylemaker on mapbox./or do it locally here */}
+              </Marker>
+            </div>
           );
         })}
       </ReactMapGl>


### PR DESCRIPTION
# Description
- Used <Tooltip> component from Ant Design to display bridge site names upon hover.
- Implemented a zoom in function to zoom in on a clicked bridge site.
- Added the FlyToInterpolator component from react-map-gl to smooth zoom in transitions.

Fixes #10

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

## Has This Been Tested

- [x] Yes
- [ ] No
- [ ] Not necessary

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
