### PR TITLE
Feat/delete bridge option/devin

### DIFF
--- a/src/components/common/BridgeForm/BridgeFormContainer.js
+++ b/src/components/common/BridgeForm/BridgeFormContainer.js
@@ -3,6 +3,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import BridgeFormAdd from './BridgeFormAdd.js';
 import BridgeFormEdit from './BridgeFormEdit.js';
 import { getAllBridges } from '../../../state/actions/index.js';
+import './styles.less';
 
 function BridgeFormContainer() {
   const dispatch = useDispatch();

--- a/src/components/common/BridgeForm/BridgeFormEdit.js
+++ b/src/components/common/BridgeForm/BridgeFormEdit.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { useDispatch } from 'react-redux';
 import { editBridge } from '../../../state/actions';
@@ -28,19 +29,26 @@ function BridgeFormEdit({ bridge }) {
   console.log('THIS IS THE BRIDGE: ', bridge);
 
   // TO DELETE BRIDGE
+  const history = useHistory();
+
   const deleteBridge = () => {
-    axios
-      .delete(`http://localhost:8000/bridges/${bridge.id}`)
-      .then(res => console.log(`${bridge} successfully deleted!`));
+    if (window.confirm('Are you sure you want to DELETE this bridge?')) {
+      axios.delete(`http://localhost:8000/bridges/${bridge.id}`).then(res => {
+        history.push('/');
+        console.log(`${bridge} successfully deleted!`);
+      });
+    } else {
+      console.log('You canceled the delete action');
+    }
   };
 
   return (
     <>
       <div style={{ display: 'flex', justifyContent: 'space-between' }}>
         <h1>Editing {bridge.name}</h1>
-        <a onClick={() => deleteBridge()} href="/">
-          <button>Delete Bridge</button>
-        </a>
+        <button className="delete-button" onClick={() => deleteBridge()}>
+          Delete Bridge
+        </button>
       </div>
       <form onSubmit={handleSubmit(onSubmit)}>
         {/* BRIDGE SITE NAME */}

--- a/src/components/common/BridgeForm/BridgeFormEdit.js
+++ b/src/components/common/BridgeForm/BridgeFormEdit.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useDispatch } from 'react-redux';
 import { editBridge } from '../../../state/actions';
+import axios from 'axios';
 
 function BridgeFormEdit({ bridge }) {
   const { register, handleSubmit, errors } = useForm();
@@ -24,10 +25,23 @@ function BridgeFormEdit({ bridge }) {
       [e.target.name]: e.target.value,
     });
   };
+  console.log('THIS IS THE BRIDGE: ', bridge);
+
+  // TO DELETE BRIDGE
+  const deleteBridge = () => {
+    axios
+      .delete(`http://localhost:8000/bridges/${bridge.id}`)
+      .then(res => console.log(`${bridge} successfully deleted!`));
+  };
 
   return (
     <>
-      <h1>Editing {bridge.name}</h1>
+      <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+        <h1>Editing {bridge.name}</h1>
+        <a onClick={() => deleteBridge()} href="/">
+          <button>Delete Bridge</button>
+        </a>
+      </div>
       <form onSubmit={handleSubmit(onSubmit)}>
         {/* BRIDGE SITE NAME */}
         <input

--- a/src/components/common/BridgeForm/styles.less
+++ b/src/components/common/BridgeForm/styles.less
@@ -1,0 +1,6 @@
+.delete-button {
+  height: 30px;
+  width: 100px;
+  color: @error-color;
+  margin: 2px 2px 0 0;
+}


### PR DESCRIPTION
# Description
- When an admin clicks a bridge to edit, they are given the option to delete that bridge
- A confirmation prompt is presented when the delete button is clicked
  - If they click **OK**, the bridge is deleted and they are redirected to the '/' route
  - Else the deletion act is canceled and they remain on the form to edit the bridge

Fixes #32 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

## Has This Been Tested

- [x] Yes
- [ ] No
- [ ] Not necessary

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
