### PR TITLE
Added renewal-green to make menu more visible

### DIFF
--- a/src/components/pages/Home/MapMenu.js
+++ b/src/components/pages/Home/MapMenu.js
@@ -77,11 +77,13 @@ function MapMenu({
           <h2>Bridge Explorer</h2>
           <div className="sign-in">
             {authState.idToken ? (
-              <button className="signin-button" onClick={logout}>
+              <button className="sign-in-btn" onClick={logout}>
                 sign out
               </button>
             ) : (
-              <a href="/login">sign in</a>
+              <button className="sign-in-btn">
+                <a href="/login">sign in</a>
+              </button>
             )}
           </div>
         </div>

--- a/src/components/pages/Home/styles.less
+++ b/src/components/pages/Home/styles.less
@@ -1,3 +1,7 @@
+// VARS
+@renewal-green: #009149;
+@clickables: #05004f;
+
 /* Wraps all the styles in the home page */
 .home-wrapper {
   .menu-cont {
@@ -17,8 +21,8 @@
     }
     .hamburger {
       position: absolute;
-      top: 10px;
-      left: -5px;
+      top: 0px;
+      left: 0px;
       z-index: 29;
       width: 60px;
       height: 60px;
@@ -26,17 +30,13 @@
       display: flex;
       align-items: center;
       justify-content: center;
-
-      @media (max-width: 500px) {
-        left: -10px;
-        top: 3px;
-      }
+      background-color: rgb(@renewal-green, 0.8);
 
       div {
         position: relative;
         flex: none;
         width: 100%;
-        height: 2px;
+        height: 3px;
         background-color: black;
         display: flex;
         align-items: center;
@@ -57,6 +57,9 @@
       div:after {
         top: 10px;
       }
+    }
+    .toggle:checked + .hamburger {
+      background-color: inherit;
     }
     // Hamburger Rotate
     .toggle:checked + .hamburger div {
@@ -146,7 +149,7 @@
           border-radius: 0px 0px 10px 10px;
 
           @media (max-width: 500px) {
-            height: 110px;
+            height: 130px;
           }
           .theme-wrap {
             border-bottom: 1px #959595 solid;

--- a/src/components/pages/Home/styles.less
+++ b/src/components/pages/Home/styles.less
@@ -1,6 +1,7 @@
 // VARS
 @renewal-green: #009149;
 @clickables: #05004f;
+@clickables-hover: #08007a;
 
 /* Wraps all the styles in the home page */
 .home-wrapper {
@@ -88,12 +89,21 @@
 
       /* sign in link styles */
       .sign-in {
-        a {
-          color: #000;
+        .sign-in-btn {
+          background-color: @clickables;
+          padding: 2px 5px;
+          border-style: none;
+          border-radius: 3px;
+          color: #f4f1f1;
+          align-items: center;
 
           &:hover {
-            color: #888;
+            background-color: @clickables-hover;
           }
+        }
+
+        a {
+          color: #f4f1f1;
         }
       }
 
@@ -198,8 +208,13 @@
               line-height: 28px;
             }
             .theme-search-icons {
+              color: @clickables;
               margin-left: 25px;
               font-size: 16px;
+
+              &:hover {
+                color: @clickables-hover;
+              }
             }
           }
 
@@ -298,7 +313,7 @@
 
           .view-bridges-btn {
             color: #ffffff;
-            background: #525252;
+            background: @clickables;
             border-radius: 5px;
             margin-bottom: 24px;
             border: none;
@@ -308,7 +323,7 @@
             transition: 0.25s;
 
             &:hover {
-              background: #666666;
+              background: @clickables-hover;
               transition: 0.25s;
             }
           }


### PR DESCRIPTION
# Description
- Added **renewal green** from Figma to use as hamb-menu background color, so it matches well with the B2P website
- Implemented color change Brian was talking about for all main clickables, using **hope blue** from Figma

Fixes #52 && touches, but doesn't resolve issue no. 50

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

## Has This Been Tested

- [x] Yes
- [ ] No
- [ ] Not necessary

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
