### PR TITLE
Menu visibility toggled to true by default

### DIFF
--- a/src/components/pages/Home/HomeContainer.js
+++ b/src/components/pages/Home/HomeContainer.js
@@ -129,7 +129,7 @@ function HomeContainer() {
   };
 
   // Passing down to MapBox, when Marker is pressed menu toggle will be set to checked
-  const [checked, setChecked] = useState(false);
+  const [checked, setChecked] = useState(true);
 
   const changeChecked = () => {
     setChecked(true);


### PR DESCRIPTION
# Description
- Set the default toggled state on the menu to be true, so mapMenu component shows on page load.

Fixes #67 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change Status

- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

## Has This Been Tested

- [x] Yes
- [ ] No
- [ ] Not necessary

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
